### PR TITLE
Fix bug that was causing the computational commitment verification to fail

### DIFF
--- a/.github/workflows/testudo.yml
+++ b/.github/workflows/testudo.yml
@@ -21,8 +21,8 @@ jobs:
         run: rustup default nightly
       - name: Install rustfmt Components
         run: rustup component add rustfmt
-      - name: Install clippy
-        run: rustup component add clippy
+      # - name: Install clippy
+      #   run: rustup component add clippy
       - name: Build
         run: cargo build --verbose
       - name: Run tests
@@ -32,6 +32,6 @@ jobs:
       - name: Check Rustfmt Code Style
         run: cargo fmt --all -- --check
       # cargo clippy uses cargo check which returns an error when asm is emitted
-      # we want to emit asm for ff operations so we avoid using clippy for now
+      # we want to emit asm for ark-ff operations so we avoid using clippy for # now
       # - name: Check clippy warnings
       #   run: cargo clippy --all-targets --all-features

--- a/src/r1csproof.rs
+++ b/src/r1csproof.rs
@@ -40,6 +40,8 @@ pub struct R1CSProof {
   proof_eval_vars_at_ry: Proof<I>,
   rx: Vec<Scalar>,
   ry: Vec<Scalar>,
+  // The transcript state after the satisfiability proof was computed.
+  pub transcript_sat_state: Scalar,
 }
 #[derive(Clone)]
 pub struct R1CSSumcheckGens {
@@ -245,6 +247,8 @@ impl R1CSProof {
 
     timer_prove.stop();
 
+    let c = transcript.challenge_scalar();
+
     (
       R1CSProof {
         comm,
@@ -255,6 +259,7 @@ impl R1CSProof {
         proof_eval_vars_at_ry,
         rx: rx.clone(),
         ry: ry.clone(),
+        transcript_sat_state: c,
       },
       rx,
       ry,
@@ -300,6 +305,7 @@ impl R1CSProof {
       input_as_sparse_poly,
       // rx: self.rx.clone(),
       ry: self.ry.clone(),
+      transcript_sat_state: self.transcript_sat_state,
     };
 
     let mut rng = ark_std::test_rng();
@@ -389,6 +395,7 @@ impl R1CSProof {
       input_as_sparse_poly,
       // rx: self.rx.clone(),
       ry: self.ry.clone(),
+      transcript_sat_state: self.transcript_sat_state,
     };
 
     let mut rng = ark_std::test_rng();


### PR DESCRIPTION
Fixes #6 

On the verifier's side, the transcript is updated partially inside the circuit and this causes the Spartan-SNARK verification to fail when the computational commitment is checked because the verifier's transcript outside the circuit was inconsistent wrt the prover's transcript. This PR provides a way to address the problem.